### PR TITLE
Update search behavior with multiple tag queries

### DIFF
--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -4,30 +4,22 @@ class BookmarksController < ApplicationController
   before_action :require_login
   before_action :set_bookmark, only: %i(show edit update destroy)
 
-  # GET /bookmarks
-  # GET /bookmarks.json
   def index
     @pagy, @bookmarks = pagy(
       Bookmark.includes(:tags).order(created_at: :desc).all, items: 10
     )
   end
 
-  # GET /bookmarks/1
-  # GET /bookmarks/1.json
   def show
   end
 
-  # GET /bookmarks/new
   def new
     @bookmark = Bookmark.new
   end
 
-  # GET /bookmarks/1/edit
   def edit
   end
 
-  # POST /bookmarks
-  # POST /bookmarks.json
   # rubocop:disable Metrics/MethodLength
   def create
     @bookmark = Bookmark.new(bookmark_params)
@@ -49,8 +41,6 @@ class BookmarksController < ApplicationController
   end
   # rubocop:enable Metrics/MethodLength
 
-  # PATCH/PUT /bookmarks/1
-  # PATCH/PUT /bookmarks/1.json
   # rubocop:disable Metrics/MethodLength
   def update
     respond_to do |format|
@@ -67,8 +57,6 @@ class BookmarksController < ApplicationController
   end
   # rubocop:enable Metrics/MethodLength
 
-  # DELETE /bookmarks/1
-  # DELETE /bookmarks/1.json
   def destroy
     @bookmark.destroy
     respond_to do |format|
@@ -84,9 +72,10 @@ class BookmarksController < ApplicationController
 
   def search
     @pagy, @bookmarks = pagy(
-      Bookmark.includes(:tags)
-              .where(tags: { name: params[:q].split(',').map(&:strip) })
-              .order(created_at: :desc).all, items: 10
+      Bookmark.includes(:tags, :taggings)
+              .tagged_with(tags_from_params)
+              .order(created_at: :desc),
+      items: 10
     )
 
     render :index
@@ -100,5 +89,9 @@ class BookmarksController < ApplicationController
 
   def bookmark_params
     params.require(:bookmark).permit(:notes, :tag_list, :title, :url)
+  end
+
+  def tags_from_params
+    params[:q].split(',').map(&:strip)
   end
 end

--- a/app/models/concerns/taggable.rb
+++ b/app/models/concerns/taggable.rb
@@ -25,4 +25,20 @@ module Taggable
       end
     end
   end
+
+  class_methods do
+    def tagged_with(values)
+      self.where("id IN (#{taggable_ids_query(values).to_sql})")
+    end
+
+    private
+
+    def taggable_ids_query(values)
+      Tagging.joins(:tag).select(:taggable_id)
+        .where(taggable_type: self.name)
+        .where(tags: { name: values })
+        .having("COUNT(*) = #{values.length}")
+        .group(:taggable_id)
+    end
+  end
 end

--- a/app/views/bookmarks/index.html.slim
+++ b/app/views/bookmarks/index.html.slim
@@ -11,7 +11,7 @@
                 = link_to bookmark.url, class: 'bookmark__url', target: '_blank' do
                   = bookmark.url
               p.card-text
-                - bookmark.tags.all.each do |tag|
+                - bookmark.tags.each do |tag|
                   span.tag.mr-1.mb-1 = tag.name
               .btn-group role="group" aria-label="Bookmark actions"
                 = link_to 'Show', bookmark, class: 'btn btn-sm btn-outline-secondary'

--- a/spec/requests/bookmarks_spec.rb
+++ b/spec/requests/bookmarks_spec.rb
@@ -29,7 +29,15 @@ RSpec.describe 'Bookmarks', type: :request do
         :tagging, taggable: bookmark1,
                   tag: tag1
       )
+      create(
+        :tagging, taggable: bookmark1,
+                  tag: tag2
+      )
 
+      create(
+        :tagging, taggable: bookmark2,
+                  tag: tag1
+      )
       create(
         :tagging, taggable: bookmark2,
                   tag: tag2


### PR DESCRIPTION
This update changes the way `bookmarks#search` performs searches, so that if multiple tags are searched for, the result will be bookmarks containing _all_ of the tags instead of _any_ of the tags.